### PR TITLE
Converted select examples from obs-shaderfilter to obs-shaderfilterplus

### DIFF
--- a/examples/VHS.hlsl
+++ b/examples/VHS.hlsl
@@ -1,0 +1,95 @@
+//based on https://www.shadertoy.com/view/Ms3XWH converted by Exeldro  v 1.0
+//original by Charles 'Surn' Fettinger for obs-shaderfilter 9/2020
+//converted and made linux compatible by John Jerome 'Wishdream' Romero for obs-shaderfilter-plus 10/2020
+
+#pragma shaderfilter set range__description Range
+#pragma shaderfilter set noiseQuality__description Noise Quality
+#pragma shaderfilter set noiseIntensity__description Noise Intensity
+#pragma shaderfilter set offsetIntensity__description Offset Intensity
+#pragma shaderfilter set colorOffsetIntensity__description Color Offset Intensity
+#pragma shaderfilter set lumaMin__description Luma Minimum
+#pragma shaderfilter set lumaMinSmooth__description Luma Minimum Smooth
+#pragma shaderfilter set Alpha_Percentage__description Alpha (%)
+#pragma shaderfilter set Alpha_Percentage__min 0
+#pragma shaderfilter set Alpha_Percentage__max 100
+#pragma shaderfilter set Alpha_Percentage__slider true
+#pragma shaderfilter set Apply_To_Image__description Apply to Image
+#pragma shaderfilter set Replace_Image_Color__description Replace Image Color
+#pragma shaderfilter set Color_To_Replace__description Color to Replace
+#pragma shaderfilter set Apply_To_Specific_Color__description Apply to Specific Color
+
+uniform float range = 0.05;
+uniform float noiseQuality = 250.0;
+uniform float noiseIntensity = 0.88;
+uniform float offsetIntensity = 0.02;
+uniform float colorOffsetIntensity = 1.3;
+uniform float lumaMin = 0.01;
+uniform float lumaMinSmooth = 0.04;
+uniform float Alpha_Percentage = 100; //<Range(0.0,100.0)>
+uniform bool Apply_To_Image;
+uniform bool Replace_Image_Color;
+uniform float4 Color_To_Replace;
+uniform bool Apply_To_Specific_Color;
+
+float rand(float2 co)
+{
+    return frac(sin(dot(co.xy ,float2(12.9898,78.233))) * 43758.5453);
+}
+
+float verticalBar(float pos, float uvY, float offset)
+{
+    float edge0 = (pos - range);
+    float edge1 = (pos + range);
+
+    float x = smoothstep(edge0, pos, uvY) * offset;
+    x -= smoothstep(pos, edge1, uvY) * offset;
+    return x;
+}
+
+float4 render(float2 st)
+{
+    float2 uv = st;
+    for (float i = 0.0; i < 0.71; i += 0.1313)
+    {
+        float d = mod((builtin_elapsed_time * i), 1.7);
+        float o = sin(1.0 - tan(builtin_elapsed_time * 0.24 * i));
+    	o *= offsetIntensity;
+        uv.x += verticalBar(d, uv.y, o);
+    }
+    float uvY = uv.y;
+    uvY *= noiseQuality;
+    uvY = float(int(uvY)) * (1.0 / noiseQuality);
+    float noise = rand(float2(builtin_elapsed_time * 0.00001, uvY));
+    uv.x += noise * noiseIntensity / 100.0;
+
+    float2 offsetR = float2(0.006 * sin(builtin_elapsed_time), 0.0) * colorOffsetIntensity;
+    float2 offsetG = float2(0.0073 * (cos(builtin_elapsed_time * 0.97)), 0.0) * colorOffsetIntensity;
+
+    float r = image.Sample(builtin_texture_sampler, uv + offsetR).r;
+    float g = image.Sample(builtin_texture_sampler, uv + offsetG).g;
+    float b = image.Sample(builtin_texture_sampler, uv).b;
+
+    float4 rgba = float4(r, g, b, 1.0);
+
+    float4 color;
+    float4 original_color;
+    if (Apply_To_Image)
+    {
+        color = image.Sample(builtin_texture_sampler, st);
+        original_color = color;
+        float4 luma = float4(dot(color, float4(0.30, 0.59, 0.11, 1.0)));
+        if (Replace_Image_Color)
+            color = luma;
+        rgba = lerp(original_color, rgba * color, clamp(Alpha_Percentage * .01, 0, 1.0));
+
+    }
+    if (Apply_To_Specific_Color)
+    {
+        color = image.Sample(builtin_texture_sampler, st);
+        original_color = color;
+        color = (distance(color.rgb, Color_To_Replace.rgb) <= 0.075) ? rgba : color;
+        rgba = lerp(original_color, color, clamp(Alpha_Percentage * .01, 0, 1.0));
+    }
+
+    return rgba;
+}

--- a/examples/VHS.hlsl
+++ b/examples/VHS.hlsl
@@ -77,7 +77,8 @@ float4 render(float2 st)
     {
         color = image.Sample(builtin_texture_sampler, st);
         original_color = color;
-        float4 luma = float4(dot(color, float4(0.30, 0.59, 0.11, 1.0)));
+        float luma_dot = dot(color, float4(0.30, 0.59, 0.11, 1.0));
+        float4 luma = float4(luma_dot, luma_dot, luma_dot, luma_dot);
         if (Replace_Image_Color)
             color = luma;
         rgba = lerp(original_color, rgba * color, clamp(Alpha_Percentage * .01, 0, 1.0));

--- a/examples/VHS.hlsl
+++ b/examples/VHS.hlsl
@@ -33,7 +33,7 @@ uniform bool Apply_To_Specific_Color;
 
 float rand(float2 co)
 {
-    return frac(sin(dot(co.xy ,float2(12.9898,78.233))) * 43758.5453);
+    return frac(sin(dot(co.xy, float2(12.9898, 78.233))) * 43758.5453);
 }
 
 float verticalBar(float pos, float uvY, float offset)
@@ -51,9 +51,9 @@ float4 render(float2 st)
     float2 uv = st;
     for (float i = 0.0; i < 0.71; i += 0.1313)
     {
-        float d = mod((builtin_elapsed_time * i), 1.7);
+        float d = fmod((builtin_elapsed_time * i), 1.7);
         float o = sin(1.0 - tan(builtin_elapsed_time * 0.24 * i));
-    	o *= offsetIntensity;
+        o *= offsetIntensity;
         uv.x += verticalBar(d, uv.y, o);
     }
     float uvY = uv.y;

--- a/examples/blink.hlsl
+++ b/examples/blink.hlsl
@@ -1,0 +1,13 @@
+//original by Charles 'Surn' Fettinger for obs-shaderfilter
+//Converted and made linux compatible by John Jerome 'Wishdream' Romero for obs-shaderfilter-plus 10/2020
+
+#pragma shaderfilter set speed__description Speed
+
+uniform float speed = 0.5;
+
+float4 render(float2 uv)
+{
+	float4 color = image.Sample(builtin_texture_sampler, uv);
+	float t = builtin_elapsed_time * speed;
+	return float4(color.r, color.g, color.b, color.a * (1 + sin(t)) / 2);
+}

--- a/examples/glitch_analog.hlsl
+++ b/examples/glitch_analog.hlsl
@@ -1,0 +1,111 @@
+// analog glitch shader by Charles Fettinger for obs-shaderfilter plugin 3/2019
+// https://github.com/Oncorporation/obs-shaderfilter
+// Converted and made linux compatible by John Jerome 'Wishdream' Romero for obs-shaderfilter-plus 10/2020
+
+#pragma shaderfilter set scan_line_jitter_displacement__description Scanline Jitter Displacement
+#pragma shaderfilter set scan_line_jitter_threshold_percent__description Scanline Jitter Threshold (%)
+#pragma shaderfilter set scan_line_jitter_threshold_percent__min 0
+#pragma shaderfilter set scan_line_jitter_threshold_percent__max 100
+#pragma shaderfilter set scan_line_jitter_threshold_percent__slider true
+#pragma shaderfilter set vertical_jump_amount__description Vertical Jump Amount
+#pragma shaderfilter set vertical_speed__description Vertical Speed
+#pragma shaderfilter set horizontal_shake__description Horizontal Shake
+#pragma shaderfilter set color_drift_amount__description Color Drift Amount
+#pragma shaderfilter set color_drift_speed__description Color Drift Speed
+#pragma shaderfilter set pulse_speed_percent__min 0
+#pragma shaderfilter set pulse_speed_percent__max 100
+#pragma shaderfilter set pulse_speed_percent__slider true
+#pragma shaderfilter set pulse_speed_percent__description Pulse Speed (%)
+#pragma shaderfilter set alpha_percent__description Alpha (%)
+#pragma shaderfilter set alpha_percent__min 0
+#pragma shaderfilter set alpha_percent__max 100
+#pragma shaderfilter set alpha_percent__slider true
+#pragma shaderfilter set rotate_colors__description Rotate Colors
+#pragma shaderfilter set Apply_To_Alpha_Layer__description Apply to Alpha
+#pragma shaderfilter set Replace_Image_Color__description Replace Image Color
+#pragma shaderfilter set Apply_To_Specific_Color__description Apply to Specific Color
+#pragma shaderfilter set Color_To_Replace__description Color to Replace
+
+uniform float scan_line_jitter_displacement = 0.33; // (displacement, threshold)
+uniform int scan_line_jitter_threshold_percent = 95;
+uniform float vertical_jump_amount;
+uniform float vertical_speed;// (amount, speed)
+uniform float horizontal_shake;
+uniform float color_drift_amount;
+uniform float color_drift_speed;// (amount, speed)
+uniform int pulse_speed_percent = 25;
+uniform int alpha_percent = 100;
+uniform bool rotate_colors;
+uniform bool Apply_To_Alpha_Layer = false;
+uniform bool Replace_Image_Color;
+uniform bool Apply_To_Specific_Color;
+uniform float4 Color_To_Replace;
+
+float nrand(float x, float y)
+{
+	float value = dot(float2(x, y), float2(12.9898 , 78.233 ));
+	return frac(sin(value) * 43758.5453);
+}
+
+float4 render(float2 uv)
+{
+	float speed = float(pulse_speed_percent) * 0.01;
+	float alpha = float(alpha_percent) * 0.01;
+	float scan_line_jitter_threshold = float(scan_line_jitter_threshold_percent) * 0.01;
+	float u = uv.x;
+	float v = uv.y;
+	float t = sin(builtin_elapsed_time * speed) * 2 - 1;
+	float4 rgba = image.Sample(builtin_texture_sampler, uv);
+
+	// Scan line jitter
+	float jitter = nrand(v, t) * 2 - 1;
+	jitter *= step(scan_line_jitter_threshold, abs(jitter)) * scan_line_jitter_displacement;
+
+	// Vertical jump
+	float jump = lerp(v, frac(v +  (t * vertical_speed)), vertical_jump_amount);
+
+	// Horizontal shake
+	float shake = ((t * (u + nrand(uv.x, uv.y))/2) - 0.5) * horizontal_shake;
+
+	//// Color drift
+	float drift = sin(jump + color_drift_speed) * color_drift_amount;
+
+	float2 src1 = float2(rgba.x, rgba.z) * clamp(frac(float2(u + jitter + shake, jump)), -10.0, 10.0);
+	float2 src2 = float2(rgba.y, rgba.w) * frac(float2(u + jitter + shake + drift, jump));
+
+	if(rotate_colors)
+	{
+		// get general time number between 0 and 4
+		float tx = (t + 1) * 2;
+		// 3 steps  c1->c2, c2->c3, c3->c1
+		//when between 0 - 1 only c1 rises then falls
+		//(min(tx, 2.0) * 0.5)  range between 0-2 converted to 0-1-0
+		src1.x = lerp(src1.x, rgba.x, clamp((min(tx, 2.0) * 0.5),0.0,0.5));
+		//((min(max(1.0, tx),3.0) - 1) * 0.5)   range between 1-3 converted to 0-1-0
+		src2.x = lerp(src2.x, rgba.y, clamp(((min(max(1.0, tx),3.0) - 1) * 0.5),0.0,0.5));
+		//((min(2.0, tx) -2) * 0.5)  range between 2 and 4  converted to 0-1-0
+		src1.y = lerp(src1.y, rgba.z, clamp(((min(2.0, tx) -2) * 0.5),0.0,0.5));
+
+	}
+
+    float4 color = rgba;
+    float4 original_color = color;
+    rgba = float4(src1.x, src2.x, src1.y, alpha);
+
+    if (Apply_To_Alpha_Layer)
+    {
+        float4 luma = float4(dot(color, float4(0.30, 0.59, 0.11, 1.0)));
+        if (Replace_Image_Color)
+            color = luma;
+        rgba = lerp(original_color, rgba * color, alpha);
+    }
+
+    if (Apply_To_Specific_Color)
+    {
+        color = original_color;
+        color = (distance(color.rgb, Color_To_Replace.rgb) <= 0.075) ? rgba : color;
+        rgba = lerp(original_color, color, alpha);
+    }
+
+    return rgba;
+}

--- a/examples/glitch_analog.hlsl
+++ b/examples/glitch_analog.hlsl
@@ -94,7 +94,8 @@ float4 render(float2 uv)
 
     if (Apply_To_Alpha_Layer)
     {
-        float4 luma = float4(dot(color, float4(0.30, 0.59, 0.11, 1.0)));
+				float luma_dot = dot(color, float4(0.30, 0.59, 0.11, 1.0));
+				float4 luma = float4(luma_dot, luma_dot, luma_dot, luma_dot);
         if (Replace_Image_Color)
             color = luma;
         rgba = lerp(original_color, rgba * color, alpha);

--- a/examples/pulse.hlsl
+++ b/examples/pulse.hlsl
@@ -1,0 +1,35 @@
+//original by Charles 'Surn' Fettinger for obs-shaderfilter
+//Converted and made linux compatible by John Jerome 'Wishdream' Romero for obs-shaderfilter-plus 10/2020
+//uv_scale and uv_offset aren't applied/ignored entirely from original
+
+#pragma shaderfilter set speed__description Speed
+#pragma shaderfilter set min_growth_pixels__description Min Growth Pixels
+#pragma shaderfilter set max_growth_pixels__description Max Growth Pixels
+
+uniform float speed;
+uniform float min_growth_pixels;
+uniform float max_growth_pixels;
+
+BuiltinVertData builtin_shader_vertex(BuiltinVertData v_in)
+{
+	BuiltinVertData vert_out;
+
+  float2 uv_pixel_interval = float2(1.0f / builtin_uv_size.x, 1.0f / builtin_uv_size.y);
+
+	float3 pos = v_in.pos.xyz;
+	float3 direction_from_center = float3((v_in.uv.x - 0.5) * uv_pixel_interval.y / uv_pixel_interval.x, v_in.uv.y - 0.5, 0);
+	float3 min_pos = pos + direction_from_center * min_growth_pixels / 2;
+	float3 max_pos = pos + direction_from_center * max_growth_pixels / 2;
+
+	float t = (1 + sin(builtin_elapsed_time * speed)) / 2;
+	float3 current_pos = min_pos * (1 - t) + max_pos * t;
+
+	vert_out.pos = mul(float4(current_pos, 1.0), ViewProj);
+	vert_out.uv = v_in.uv;
+	return vert_out;
+}
+
+float4 render(float2 uv)
+{
+  return image.Sample(builtin_texture_sampler, uv);
+}

--- a/examples/pulse.hlsl
+++ b/examples/pulse.hlsl
@@ -6,9 +6,9 @@
 #pragma shaderfilter set min_growth_pixels__description Min Growth Pixels
 #pragma shaderfilter set max_growth_pixels__description Max Growth Pixels
 
-uniform float speed;
-uniform float min_growth_pixels;
-uniform float max_growth_pixels;
+uniform float speed = 1.0;
+uniform float min_growth_pixels = -2.0;
+uniform float max_growth_pixels = 2.0;
 
 BuiltinVertData builtin_shader_vertex(BuiltinVertData v_in)
 {

--- a/examples/pulse.hlsl
+++ b/examples/pulse.hlsl
@@ -6,9 +6,9 @@
 #pragma shaderfilter set min_growth_pixels__description Min Growth Pixels
 #pragma shaderfilter set max_growth_pixels__description Max Growth Pixels
 
-uniform float speed = 1.0;
-uniform float min_growth_pixels = -2.0;
-uniform float max_growth_pixels = 2.0;
+uniform float speed = 2.0;
+uniform float min_growth_pixels = -50.0;
+uniform float max_growth_pixels = 50.0;
 
 BuiltinVertData builtin_shader_vertex(BuiltinVertData v_in)
 {

--- a/examples/rotatoe.hlsl
+++ b/examples/rotatoe.hlsl
@@ -1,0 +1,90 @@
+// Rotation Effect By Charles Fettinger (https://github.com/Oncorporation)  10/2019
+// Converted and made linux compatible by John Jerome 'Wishdream' Romero for obs-shaderfilter-plus 10/2020
+// uv_scale and uv_offset aren't applied/ignored entirely from original
+// rotate pixels ay not work may not work as intended
+
+#pragma shaderfilter set speed_percent__description Speed (%)
+#pragma shaderfilter set Axis_X__description X
+#pragma shaderfilter set Axis_Y__description Y
+#pragma shaderfilter set Axis_Z__description Z
+#pragma shaderfilter set Angle_Degrees__Angle (Degrees)
+#pragma shaderfilter set Rotate_Transform__description Rotate Transform
+#pragma shaderfilter set Rotate_Pixels__description Rotate Pixels
+#pragma shaderfilter set Rotate_Colors__description Rotate Colors
+#pragma shaderfilter set center_width_percentage__description Rotation Center X (%)
+#pragma shaderfilter set center_width_percentage__min 0
+#pragma shaderfilter set center_width_percentage__max 100
+#pragma shaderfilter set center_width_percentage__slider true
+#pragma shaderfilter set center_height_percentage__description Rotation Center Y (%)
+#pragma shaderfilter set center_height_percentage__min 0
+#pragma shaderfilter set center_height_percentage__max 100
+#pragma shaderfilter set center_height_percentage__slider true
+
+uniform int speed_percent = 50; //<Range(-10.0, 10.0)>
+uniform float Axis_X = 0.0;
+uniform float Axis_Y = 0.0;
+uniform float Axis_Z = 1.0;
+uniform float Angle_Degrees = 45.0;
+uniform bool Rotate_Transform = true;
+uniform bool Rotate_Pixels = false;
+uniform bool Rotate_Colors = false;
+uniform int center_width_percentage = 50;
+uniform int center_height_percentage = 50;
+
+float3x3 rotAxis(float3 axis, float a) {
+	float s=sin(a);
+	float c=cos(a);
+	float oc=1.0-c;
+
+	float3 as=axis*s;
+
+	float3x3 p=float3x3(axis.x*axis,axis.y*axis,axis.z*axis);
+	float3x3 q=float3x3(c,-as.z,as.y,as.z,c,-as.x,-as.y,as.x,c);
+	return p*oc+q;
+}
+
+BuiltinVertData builtin_shader_vertex(BuiltinVertData v_in)
+{
+	BuiltinVertData vert_out;
+	vert_out.pos =  mul(float4(v_in.pos.xyz, 1.0), ViewProj);
+
+	float speed = float(speed_percent) * 0.01;
+	// circular easing variable
+	float PI = 3.1415926535897932384626433832795; //acos(-1);
+	float PI180th = 0.0174532925; //PI divided by 180
+	float direction = abs(sin((builtin_elapsed_time - 0.001) * speed));
+	float t = sin(builtin_elapsed_time * speed);
+	float angle_degrees = PI180th * Angle_Degrees;
+
+	// use matrix to transform rotation
+	if (Rotate_Transform)
+		vert_out.pos.xyz = mul(vert_out.pos.xyz,rotAxis(float3(Axis_X,Axis_Y,Axis_Z), (angle_degrees * t))).xyz;
+
+	vert_out.uv  = v_in.uv;
+
+	return vert_out;
+}
+
+float4 render(float2 uv)
+{
+	float4 rgba = image.Sample(builtin_texture_sampler, uv);
+
+	float speed = float(speed_percent) * 0.01;
+	// circular easing variable
+	float PI = 3.1415926535897932384626433832795; //acos(-1);
+	float PI180th = 0.0174532925; //PI divided by 180
+	float direction = abs(sin((builtin_elapsed_time - 0.001) * speed));
+	float t = sin(builtin_elapsed_time * speed);
+	float angle_degrees = PI180th * Angle_Degrees;
+
+	// use matrix to transform pixels
+	if (Rotate_Pixels)
+	{
+		float2 center_pixel_coordinates = float2(float(center_width_percentage) * 0.01, float(center_height_percentage) * 0.01 );
+		rgba = image.Sample(builtin_texture_sampler, mul(uv - center_pixel_coordinates, float2(rotAxis(float3(Axis_X ,Axis_Y, Axis_Z ), (angle_degrees * t))) ).xy + center_pixel_coordinates);
+	}
+	if (Rotate_Colors)
+		rgba.rgb = mul(rgba.rgb, rotAxis(float3(Axis_X,Axis_Y,Axis_Z), (angle_degrees * t))).xyz;
+
+	return rgba;
+}

--- a/examples/rotatoe.hlsl
+++ b/examples/rotatoe.hlsl
@@ -81,7 +81,9 @@ float4 render(float2 uv)
 	if (Rotate_Pixels)
 	{
 		float2 center_pixel_coordinates = float2(float(center_width_percentage) * 0.01, float(center_height_percentage) * 0.01 );
-		rgba = image.Sample(builtin_texture_sampler, mul(uv - center_pixel_coordinates, float2(rotAxis(float3(Axis_X ,Axis_Y, Axis_Z ), (angle_degrees * t))) ).xy + center_pixel_coordinates);
+		float3x3 rotate_axis = rotAxis(float3(Axis_X ,Axis_Y, Axis_Z), (angle_degrees * t));
+		float3 rotate_uv = mul(float3(uv - center_pixel_coordinates, 0), rotate_axis);
+		rgba = image.Sample(builtin_texture_sampler, rotate_uv.xy + center_pixel_coordinates);
 	}
 	if (Rotate_Colors)
 		rgba.rgb = mul(rgba.rgb, rotAxis(float3(Axis_X,Axis_Y,Axis_Z), (angle_degrees * t))).xyz;

--- a/examples/scan_line.hlsl
+++ b/examples/scan_line.hlsl
@@ -1,0 +1,81 @@
+// Scan Line Effect for OBS Studio
+// originally from Andersama (https://github.com/Andersama)
+// Modified and improved my Charles Fettinger (https://github.com/Oncorporation)  1/2019
+// Converted and made linux compatible by John Jerome 'Wishdream' Romero for obs-shaderfilter-plus 10/2020
+
+#pragma shaderfilter set lengthwise__description Lengthwise
+#pragma shaderfilter set animate__description Animate
+#pragma shaderfilter set speed__description Speed
+#pragma shaderfilter set angle__description Angle (Degrees)
+#pragma shaderfilter set shift__description Shift
+#pragma shaderfilter set boost__description Boost
+#pragma shaderfilter set floor__description Floor
+#pragma shaderfilter set period__description Period
+
+//Count the number of scanlines we want via height or width, adjusts the sin wave period
+uniform bool lengthwise;
+//Do we want the scanlines to move?
+uniform bool animate = true;
+//How fast do we want those scanlines to move?
+uniform float speed = 1000;
+//What angle should the scanlines come in at (based in degrees)
+uniform float angle = 90;
+//Turns on adjustment of the results, sin returns -1 -> 1 these settings will change the results a bit
+//By default values for color range from 0 to 1
+//Boost centers the result of the sin wave on 1*, to help maintain the brightness of the screen
+uniform bool shift = true;
+uniform bool boost = true;
+//Increases the minimum value of the sin wave
+uniform float floor = 60.0;
+//final adjustment to the period of the sin wave, we can't / 0, need to be careful w/ user input
+uniform float period = 10.0;
+float4 render(float2 uv)
+{
+	//3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117067982148086513282306647093844609550582231725359408128481 							3.141592653589793238462643383279502884197169399375105820974944592307816406286
+	//float pix2 = 6.2831853071795864769252;//86766559005768394338798750211641949
+	float nfloor = clamp(floor, 0.0, 100.0) * 0.01;
+	float nperiod = max(period, 1.0);
+	float gap = 1 - nfloor;
+	float pi   = 3.1415926535897932384626;
+	float2 direction = float2( cos(angle * pi / 180.0) , sin(angle * pi / 180.0) );
+	float nspeed = 0.0;
+
+  float2 uv_pixel_interval = float2(1.0f / builtin_uv_size.x, 1.0f / builtin_uv_size.y);
+
+	if(animate){
+		nspeed = speed * 0.0001;
+	}
+
+	float4 color = image.Sample(builtin_texture_sampler, uv);
+
+	float t = builtin_elapsed_time * nspeed;
+
+	if(!lengthwise){
+		float base_height = 1.0 / uv_pixel_interval.y;
+		float h_interval = pi * base_height;
+
+		float rh_sin = sin(((uv.y * direction.y + uv.x * direction.x) + t) * (h_interval / nperiod));
+		if(shift){
+			rh_sin = ((1.0 + rh_sin) * 0.5) * gap + nfloor;
+			if(boost){
+				rh_sin += gap * 0.5;
+			}
+		}
+		float4 s_mult = float4(rh_sin,rh_sin,rh_sin,1);
+		return s_mult * color;
+	}
+	else{
+		float base_width = 1.0 / uv_pixel_interval.x;
+		float w_interval = pi * base_width;
+
+		float rh_sin = sin(((uv.y * direction.y + uv.x * direction.x) + t) * (w_interval / nperiod));
+		if(shift){
+			rh_sin = ((1.0 + rh_sin) * 0.5) * gap + nfloor;
+			if(boost){
+				rh_sin += gap * 0.5;
+			}
+		}
+		float4 s_mult = float4(rh_sin,rh_sin,rh_sin,1);
+		return s_mult * color;
+	}
+}

--- a/examples/shake.hlsl
+++ b/examples/shake.hlsl
@@ -23,7 +23,7 @@ uniform float max_worble_size = 100.0;
 
 //random values in range if 0.0 to 1.0
 float noise_gen(float n){
-  return fract(sin(n) * 43758.5453f);
+  return frac(sin(n) * 43758.5453f);
 }
 
 BuiltinVertData builtin_shader_vertex(BuiltinVertData v_in)

--- a/examples/shake.hlsl
+++ b/examples/shake.hlsl
@@ -1,0 +1,91 @@
+// Shake Effect By Charles Fettinger (https://github.com/Oncorporation)  2/2019
+// Added some randomization based upon random_scale input
+// Converted and made linux compatible by John Jerome 'Wishdream' Romero for obs-shaderfilter-plus 10/2020
+// uv_scale and uv_offset aren't applied/ignored entirely from original
+// rotate pixels ay not work may not work as intended
+
+#pragma shaderfilter set speed__description Speed
+#pragma shaderfilter set random_scale__description Random Scale
+#pragma shaderfilter set worble__description Worble
+#pragma shaderfilter set min_growth_pixels__description Min Growth Pixels
+#pragma shaderfilter set max_growth_pixels__description Max Growth Pixels
+#pragma shaderfilter set randomize_movement__description Randomize Movement
+
+uniform float speed = 1.0;
+uniform float random_scale = 0.25;
+uniform bool worble = false;
+uniform float min_growth_pixels = -2.0;
+uniform float max_growth_pixels = 2.0;
+uniform bool randomize_movement = false;
+
+float noise2D(float2 uv)
+{
+  float value = dot(uv, float2(12.9898 , 78.233 ));
+	return frac(sin(value) * 43758.5453);
+}
+//noise values in range if 0.0 to 1.0
+
+float noise3D(float x, float y, float z) {
+    float ptr = 0.0f;
+    return frac(sin(x*112.9898f + y*179.233f + z*237.212f) * 43758.5453f);
+}
+
+BuiltinVertData builtin_shader_vertex(BuiltinVertData v_in)
+{
+	BuiltinVertData vert_out;
+  float rand_f = noise2D(v_in.uv);
+  float2 uv_pixel_interval = float2(1.0f / builtin_uv_size.x, 1.0f / builtin_uv_size.y);
+
+	float3 pos = v_in.pos.xyz;
+	float t;
+	float s;
+	float noise;
+
+	if (randomize_movement)
+	{
+		t = (rand_f * 2) - 1.0f;
+    s = (1 - rand_f * 2) - 1.0f;
+		noise = clamp( rand_f * random_scale,-0.99, 0.99);
+	}
+	else
+	{
+		t = (1 + sin(builtin_elapsed_time * speed)) / 2;
+		s = (1 + cos(builtin_elapsed_time * speed)) / 2;
+		noise = clamp(noise3D(t,s,100) * random_scale,-0.99, 0.99);
+	}
+
+	float3 direction_from_center = float3((v_in.uv.x - 0.5 + noise) * uv_pixel_interval.y / uv_pixel_interval.x, v_in.uv.y - 0.5 + noise, 1);
+	float3 min_pos;
+	float3 max_pos;
+    if (worble)
+    {
+        min_pos = pos + direction_from_center * min_growth_pixels * 0.5;
+        max_pos = pos + direction_from_center * max_growth_pixels * 0.5;
+    }
+    else
+    {
+    	min_pos = pos + direction_from_center * 0.5;
+		max_pos = min_pos;
+    }
+
+	float3 current_pos = min_pos * (1 - t) + max_pos * t;
+	//current_pos.x = v_in.pos.x + (t * min_pos.x);
+	current_pos.y = (min_pos.y * (1 - s) + max_pos.y * s);
+	//current_pos.y = v_in.pos.y + (s * min_pos.y);
+	//current_pos.z = min_pos.z * (1 - s) + max_pos.z * s;
+
+	float2 offset = float2(1 - t + noise, 1 - s + noise);
+
+	vert_out.pos = mul(float4(current_pos, 1), ViewProj);
+
+	//float2 scale = uv_scale;
+	//scale += dot(pos - current_pos, 1);
+
+	vert_out.uv = v_in.uv  + offset;
+	return vert_out;
+}
+
+float4 render(float2 uv)
+{
+  return image.Sample(builtin_texture_sampler, uv);
+}

--- a/examples/shake.hlsl
+++ b/examples/shake.hlsl
@@ -1,87 +1,85 @@
-// Shake Effect By Charles Fettinger (https://github.com/Oncorporation)  2/2019
-// Added some randomization based upon random_scale input
-// Converted and made linux compatible by John Jerome 'Wishdream' Romero for obs-shaderfilter-plus 10/2020
-// uv_scale and uv_offset aren't applied/ignored entirely from original
-// rotate pixels ay not work may not work as intended
+// Shake Effect By John Jerome 'Wishdream' Romero (https://github.com/Wishdream)  1/2021
+// Rewritten and based from shake effect By Charles Fettinger (https://github.com/Oncorporation)
 
-#pragma shaderfilter set speed__description Speed
-#pragma shaderfilter set random_scale__description Random Scale
+#pragma shaderfilter set magnitude__description Magnitude
+#pragma shaderfilter set magnitude__min -1
+#pragma shaderfilter set magnitude__max 1
+#pragma shaderfilter set random_position__description Random Position
+#pragma shaderfilter set rotation_speed__description Rotation Speed
+#pragma shaderfilter set rotation_distance__description Rotation Distance
 #pragma shaderfilter set worble__description Worble
-#pragma shaderfilter set min_growth_pixels__description Min Growth Pixels
-#pragma shaderfilter set max_growth_pixels__description Max Growth Pixels
-#pragma shaderfilter set randomize_movement__description Randomize Movement
+#pragma shaderfilter set min_worble_size__description Min Worble Pixel Size
+#pragma shaderfilter set max_worble_size__description Max Worble Pixel Size
 
-uniform float speed = 1.0;
-uniform float random_scale = 0.25;
+uniform float magnitude = 0.05;
+uniform bool random_position = false;
+uniform float rotation_speed = 2;
+uniform float rotation_distance = 0.25;
+
 uniform bool worble = false;
-uniform float min_growth_pixels = -2.0;
-uniform float max_growth_pixels = 2.0;
-uniform bool randomize_movement = false;
+uniform float worble_speed = 5;
+uniform float min_worble_size = -100.0;
+uniform float max_worble_size = 100.0;
 
-float noise2D(float2 uv)
-{
-  float value = dot(uv, float2(12.9898 , 78.233 ));
-	return frac(sin(value) * 43758.5453);
-}
-//noise values in range if 0.0 to 1.0
-
-float noise3D(float x, float y, float z) {
-    float ptr = 0.0f;
-    return frac(sin(x*112.9898f + y*179.233f + z*237.212f) * 43758.5453f);
+//random values in range if 0.0 to 1.0
+float noise_gen(float n){
+  return fract(sin(n) * 43758.5453f);
 }
 
 BuiltinVertData builtin_shader_vertex(BuiltinVertData v_in)
 {
-	BuiltinVertData vert_out;
-  float rand_f = noise2D(v_in.uv);
+  BuiltinVertData vert_out;
   float2 uv_pixel_interval = float2(1.0f / builtin_uv_size.x, 1.0f / builtin_uv_size.y);
 
-	float3 pos = v_in.pos.xyz;
-	float t;
-	float s;
-	float noise;
+  // Position defaults
+  float3 pos = v_in.pos.xyz;
+  float t;
+  float s;
 
-	if (randomize_movement)
-	{
-		t = (rand_f * 2) - 1.0f;
-    s = (1 - rand_f * 2) - 1.0f;
-		noise = clamp( rand_f * random_scale,-0.99, 0.99);
-	}
-	else
-	{
-		t = (1 + sin(builtin_elapsed_time * speed)) / 2;
-		s = (1 + cos(builtin_elapsed_time * speed)) / 2;
-		noise = clamp(noise3D(t,s,100) * random_scale,-0.99, 0.99);
-	}
+  // Random defaults * magnitude
+  float2 rand2;
+  float noise;
+  rand2.x = noise_gen(builtin_elapsed_time) * 2 - 1.0f;
+  rand2.y = noise_gen(builtin_elapsed_time / 2) * 2 - 1.0f;
+  rand2 *= magnitude;
 
-	float3 direction_from_center = float3((v_in.uv.x - 0.5 + noise) * uv_pixel_interval.y / uv_pixel_interval.x, v_in.uv.y - 0.5 + noise, 1);
-	float3 min_pos;
-	float3 max_pos;
-    if (worble)
-    {
-        min_pos = pos + direction_from_center * min_growth_pixels * 0.5;
-        max_pos = pos + direction_from_center * max_growth_pixels * 0.5;
-    }
-    else
-    {
-    	min_pos = pos + direction_from_center * 0.5;
-		max_pos = min_pos;
-    }
+  if (random_position)
+  {
+      t = rand2.x;
+      s = rand2.y;
+  }
+  else
+  {
+      t = sin(builtin_elapsed_time * rotation_speed) * rotation_distance;
+      s = cos(builtin_elapsed_time * rotation_speed) * rotation_distance;
+  }
 
-	float3 current_pos = min_pos * (1 - t) + max_pos * t;
-	//current_pos.x = v_in.pos.x + (t * min_pos.x);
-	current_pos.y = (min_pos.y * (1 - s) + max_pos.y * s);
-	//current_pos.y = v_in.pos.y + (s * min_pos.y);
-	//current_pos.z = min_pos.z * (1 - s) + max_pos.z * s;
+  float3 direction_from_center = float3((v_in.uv.x - 0.5 + rand2.x) * uv_pixel_interval.y / uv_pixel_interval.x, v_in.uv.y - 0.5 + rand2.y, 1);
+  float3 min_pos;
+  float3 max_pos;
+  float tvec;
+  float svec;
 
-	float2 offset = float2(1 - t + noise, 1 - s + noise);
+  if (worble)
+  {
+    tvec = sin(builtin_elapsed_time * worble_speed) * 0.5;
+    svec = cos(builtin_elapsed_time * worble_speed) * 0.5;
+    min_pos = pos + direction_from_center * min_worble_size * 0.5;
+    max_pos = pos + direction_from_center * max_worble_size * 0.5;
+  }
+  else
+  {
+    tvec = t;
+    svec = s;
+    min_pos = pos + direction_from_center * 0.5;
+    max_pos = min_pos;
+  }
 
-	vert_out.pos = mul(float4(current_pos, 1), ViewProj);
-
-	//float2 scale = uv_scale;
-	//scale += dot(pos - current_pos, 1);
-
-	vert_out.uv = v_in.uv  + offset;
+  pos = min_pos * (1 - tvec) + max_pos * tvec;
+  pos.y = (min_pos.y * (1 - svec) + max_pos.y * svec);
+  float2 offset = float2(s + rand2.y, t + rand2.x);
+  vert_out.pos = mul(float4(pos, 1), ViewProj);
+	vert_out.uv = v_in.uv + offset;
 	return vert_out;
 }
 


### PR DESCRIPTION
I figure I'd help out on #7 by converting some of the filters I'm using from [obs-shaderfilter](https://github.com/Oncorporation/obs-shaderfilter).
Made sure these worked well in Linux and the GLSL conversion. I can't test this in Windows but I'm sure it should work.

It contains both basic and advanced shaders. However, it has some vertex shaders too referring to the example in src.
I would recommend testing this first on a Windows PC before merging just incase since I can't.
Especially since it's doing the GLSL conversion from HLSL and I had to correct the syntax to make it work.

I'll be porting the rest that I can from obs-shaderfilter if this works fine and if it's compatible. (Since I know some require another texture2d and is not currently supported.)