### PR TITLE
Adding more example-shaders

### DIFF
--- a/examples/background_colors.glsl
+++ b/examples/background_colors.glsl
@@ -1,0 +1,16 @@
+#pragma shaderfilter set opacity__description Opacity
+#pragma shaderfilter set opacity__default 0.3
+#pragma shaderfilter set opacity__min 0
+#pragma shaderfilter set opacity__max 1
+#pragma shaderfilter set opacity__step 0.01
+#pragma shaderfilter set opacity__slider true
+uniform float opacity;
+
+float4 render(float2 uv){
+    float time = builtin_elapsed_time;
+
+    float r = sin(uv.x + time) * 0.5 + 0.5;
+    float g = sin(uv.y - time) * 0.5 + 0.5;
+    float b = sin(time) * 0.5 + 0.5;
+    return opacity * float4(r, g, b, 1.0) + (1 - opacity) * image.Sample(builtin_texture_sampler, uv);
+}

--- a/examples/background_colors.glsl
+++ b/examples/background_colors.glsl
@@ -6,11 +6,19 @@
 #pragma shaderfilter set opacity__slider true
 uniform float opacity;
 
+#pragma shaderfilter set speed__description Speed
+#pragma shaderfilter set speed__default 1
+#pragma shaderfilter set speed__min 0
+#pragma shaderfilter set speed__max 10
+#pragma shaderfilter set speed__step 0.01
+#pragma shaderfilter set speed__slider true
+uniform float speed;
+
 float4 render(float2 uv){
     float time = builtin_elapsed_time;
 
-    float r = sin(uv.x + time) * 0.5 + 0.5;
-    float g = sin(uv.y - time) * 0.5 + 0.5;
-    float b = sin(time) * 0.5 + 0.5;
+    float r = sin(uv.x + time * speed) * 0.5 + 0.5;
+    float g = sin(uv.y - time * speed) * 0.5 + 0.5;
+    float b = sin(time * speed) * 0.5 + 0.5;
     return opacity * float4(r, g, b, 1.0) + (1 - opacity) * image.Sample(builtin_texture_sampler, uv);
 }

--- a/examples/background_tiles.glsl
+++ b/examples/background_tiles.glsl
@@ -1,0 +1,65 @@
+#pragma shaderfilter set opacity__description Opacity
+#pragma shaderfilter set opacity__default 0.3
+#pragma shaderfilter set opacity__min 0
+#pragma shaderfilter set opacity__max 1
+#pragma shaderfilter set opacity__step 0.01
+#pragma shaderfilter set opacity__slider true
+uniform float opacity;
+
+#pragma shaderfilter set size__description Size
+#pragma shaderfilter set size__default 100
+#pragma shaderfilter set size__min 1
+#pragma shaderfilter set size__max 250
+#pragma shaderfilter set size__step 1
+#pragma shaderfilter set size__slider true
+uniform float size;
+
+#pragma shaderfilter set speed__description Speed
+#pragma shaderfilter set speed__default 0.5
+#pragma shaderfilter set speed__min 0
+#pragma shaderfilter set speed__max 10
+#pragma shaderfilter set speed__step 0.01
+#pragma shaderfilter set speed__slider true
+uniform float speed;
+
+// https://www.shadertoy.com/view/wscGWl
+// Credits to reyemxela
+
+float rand(float2 co){ return fract(sin(dot(co.xy ,float2(12.9898,78.233))) * 43758.5453); } // random noise
+
+float getCellBright(float2 id) {
+    return sin((builtin_elapsed_time+2.)*rand(id)*2.)*.5+.5; // returns 0. to 1.
+}
+
+float4 render(float2 uv) {
+    float2 pos = uv;
+
+    float mx = max(builtin_uv_size.x, builtin_uv_size.y);
+    uv = uv * builtin_uv_size / mx;
+
+    float time = builtin_elapsed_time*speed;
+
+    uv *= size; // grid size
+
+    float2 id = floor(uv); // id numbers for each cell
+    float2 gv = fract(uv)-.5; // uv within each cell, from -.5 to .5
+
+    float3 color = float3(0.);
+
+    float randBright = getCellBright(id);
+
+    float3 colorShift = float3(rand(id)*.1); // subtle random color offset per cell
+
+    color = 0.6 + 0.5*cos(time + (id.xyx*.025) + float3(4,2,1) + colorShift); // RGB with color offset
+
+    float shadow = 0.;
+    shadow += smoothstep(.0, .7,  gv.x*min(0., (getCellBright(float2(id.x-1., id.y)) - getCellBright(id)))); // left shadow
+    shadow += smoothstep(.0, .7, -gv.y*min(0., (getCellBright(float2(id.x, id.y+1.)) - getCellBright(id)))); // top shadow
+
+    color -= shadow*.4;
+
+    color *= 1. - (randBright*.2);
+
+    return opacity * float4(color, 1.0) * float4(0.7, 0.7, 0.7, 1.0) + (1 - opacity) * image.Sample(builtin_texture_sampler, pos);
+
+}

--- a/examples/blur.glsl
+++ b/examples/blur.glsl
@@ -1,0 +1,25 @@
+#pragma shaderfilter set kernel_size__description Kernel size
+#pragma shaderfilter set kernel_size__default 0
+#pragma shaderfilter set kernel_size__min 0
+#pragma shaderfilter set kernel_size__max 20
+#pragma shaderfilter set kernel_size__step 1
+#pragma shaderfilter set kernel_size__slider true
+uniform int kernel_size;
+
+float4 render(float2 uv) {
+	float2 coords = builtin_uv_size * uv;
+
+	float4 col = float4(0.0, 0.0, 0.0, 0.0);
+	int count = 0;
+	for (int i = -kernel_size; i <= kernel_size; i++) {
+		for (int j = -kernel_size; j <= kernel_size; j++) {
+			float2 pos = (coords + float2(i, j)) / builtin_uv_size;
+			if (pos.x >= 0 && pos.y >= 0 && pos.x <= 1 && pos.y <= 1)
+				count++;
+			col += image.Sample(builtin_texture_sampler, pos);
+		}
+	}
+	col /= count;
+
+	return col;
+}

--- a/examples/edge_detection.glsl
+++ b/examples/edge_detection.glsl
@@ -1,0 +1,33 @@
+#pragma shaderfilter set threshold__description Threshold
+#pragma shaderfilter set threshold__default 1
+#pragma shaderfilter set threshold__min 0.01
+#pragma shaderfilter set threshold__max 10
+#pragma shaderfilter set threshold__step 0.01
+#pragma shaderfilter set threshold__slider true
+uniform float threshold;
+
+float avg(float4 col) {
+    return (col.r + col.g + col.b) / 3.0;
+}
+
+float4 render(float2 uv) {
+    float2 coords = builtin_uv_size * uv;
+    int kernel[9] = int[] (1, 2, 1, 0, 0, 0, -1, -2, -1);
+
+    float hsum = 0.0f, vsum = 0.0f;
+    for (int i = -1; i < 2; i++) {
+        for (int j = -1; i < 2; i++) {
+            float2 pos1 = (coords + float2(j, i)) / builtin_uv_size;
+            float2 pos2 = (coords + float2(i, j)) / builtin_uv_size;
+            if (pos1.x >= 0 && pos1.y >= 0 && pos1.x <= 1 && pos1.y <= 1)
+                hsum += avg(image.Sample(builtin_texture_sampler, pos1)) * kernel[(i + 1) * 3 + j + 1];
+            if (pos2.x >= 0 && pos2.y >= 0 && pos2.x <= 1 && pos2.y <= 1)
+                vsum += avg(image.Sample(builtin_texture_sampler, pos2)) * kernel[(i + 1) * 3 + j + 1];
+        }
+    }
+
+    float res = max(abs(hsum), abs(vsum));
+    if (res >= threshold / 10.0)
+        res = 1;
+    return float4(res, res, res, 1.0);
+}

--- a/examples/edge_detection_color.glsl
+++ b/examples/edge_detection_color.glsl
@@ -1,0 +1,22 @@
+float4 render(float2 uv) {
+    float2 coords = builtin_uv_size * uv;
+    int kernel[9] = int[] (1, 2, 1, 0, 0, 0, -1, -2, -1);
+
+    float4 col = float4(0.0, 0.0, 0.0, 1.0);
+    for (int a = 0; a < 3; a++) {
+        float hsum = 0.0f, vsum = 0.0f;
+        for (int i = -1; i < 2; i++) {
+            for (int j = -1; i < 2; i++) {
+                float2 pos1 = (coords + float2(j, i)) / builtin_uv_size;
+                float2 pos2 = (coords + float2(i, j)) / builtin_uv_size;
+                if (pos1.x >= 0 && pos1.y >= 0 && pos1.x <= 1 && pos1.y <= 1)
+                    hsum += image.Sample(builtin_texture_sampler, pos1)[a] * kernel[(i + 1) * 3 + j + 1];
+                if (pos2.x >= 0 && pos2.y >= 0 && pos2.x <= 1 && pos2.y <= 1)
+                    vsum += image.Sample(builtin_texture_sampler, pos2)[a] * kernel[(i + 1) * 3 + j + 1];
+            }
+        }
+        col[a] = max(abs(hsum), abs(vsum));
+    }
+
+    return col;
+}

--- a/examples/edge_detection_toon.glsl
+++ b/examples/edge_detection_toon.glsl
@@ -1,0 +1,33 @@
+#pragma shaderfilter set threshold__description Threshold
+#pragma shaderfilter set threshold__default 1
+#pragma shaderfilter set threshold__min 0.01
+#pragma shaderfilter set threshold__max 10
+#pragma shaderfilter set threshold__step 0.01
+#pragma shaderfilter set threshold__slider true
+uniform float threshold;
+
+float avg(float4 col) {
+    return (col.r + col.g + col.b) / 3.0;
+}
+
+float4 render(float2 uv) {
+    float2 coords = builtin_uv_size * uv;
+    int kernel[9] = int[] (1, 2, 1, 0, 0, 0, -1, -2, -1);
+
+    float hsum = 0.0f, vsum = 0.0f;
+    for (int i = -1; i < 2; i++) {
+        for (int j = -1; i < 2; i++) {
+            float2 pos1 = (coords + float2(j, i)) / builtin_uv_size;
+            float2 pos2 = (coords + float2(i, j)) / builtin_uv_size;
+            if (pos1.x >= 0 && pos1.y >= 0 && pos1.x <= 1 && pos1.y <= 1)
+                hsum += avg(image.Sample(builtin_texture_sampler, pos1)) * kernel[(i + 1) * 3 + j + 1];
+            if (pos2.x >= 0 && pos2.y >= 0 && pos2.x <= 1 && pos2.y <= 1)
+                vsum += avg(image.Sample(builtin_texture_sampler, pos2)) * kernel[(i + 1) * 3 + j + 1];
+        }
+    }
+
+    float res = max(abs(hsum), abs(vsum));
+    if (res >= threshold / 10.0)
+        res = 1;
+    return float4(1 - res, 1 - res, 1 - res, 1.0) * image.Sample(builtin_texture_sampler, uv);
+}


### PR DESCRIPTION
This pull request adds some more shaders to the examples folder. One to blur the incoming video, three to do different kinds of edge detection and two to add some background effect.
Below you can find some screenshots of how these shaders look, note that both the background_* shaders are used together with the edge_detection one just because i think it looks cool, these two should also be changing over time, but don't, since these are only still images. Also the background_colors shader (second last) got a speed slider since taking these screenshots.
![blur](https://user-images.githubusercontent.com/41524490/127657331-4458ab5d-d105-4905-8a37-339bc8407867.png)
![edge_detection](https://user-images.githubusercontent.com/41524490/127657344-18d2d0c5-8778-42ff-b89c-bdf208f29ea2.png)
![edge_detection_color](https://user-images.githubusercontent.com/41524490/127657352-839cbd75-6afd-41bd-be97-04257b2250e9.png)
![edge_detection_toon](https://user-images.githubusercontent.com/41524490/127657355-bf93a2c5-ecbf-42b2-a887-cbd9e63d752c.png)
![background_colors](https://user-images.githubusercontent.com/41524490/127657371-287c9e3d-3568-499c-a198-42392234aea9.png)
![background_tiles](https://user-images.githubusercontent.com/41524490/127657375-ab4483ca-84d3-4a82-a789-a7c95ba5bd3e.png)